### PR TITLE
Migrate raft package into its own internal/raft folder

### DIFF
--- a/server/internal/raft/raft.go
+++ b/server/internal/raft/raft.go
@@ -1,4 +1,4 @@
-package raftpb
+package raft
 
 import (
 	"context"

--- a/server/main.go
+++ b/server/main.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	raft "github.com/djsurt/monkey-minder/server/internal"
+	"github.com/djsurt/monkey-minder/server/internal/raft"
 	raftpb "github.com/djsurt/monkey-minder/server/proto/raft"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"


### PR DESCRIPTION
Moving the raft package into its own internal folder package for consistency with other internal packages.
